### PR TITLE
refact: update joi a data validation library to a supported version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,46 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@hapi/address": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.2.tgz",
+      "integrity": "sha512-O4QDrx+JoGKZc6aN64L04vqa7e41tIiLU+OvKdcYaEMP97UttL0f9GIi9/0A4WAMx0uBd6SidDIhktZhgOcN8Q=="
+    },
+    "@hapi/formula": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-1.2.0.tgz",
+      "integrity": "sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA=="
+    },
+    "@hapi/hoek": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
+      "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
+    },
+    "@hapi/joi": {
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.7.tgz",
+      "integrity": "sha512-anaIgnZhNooG3LJLrTFzgGALTiO97zRA1UkvQHm9KxxoSiIzCozB3RCNCpDnfhTJD72QlrHA8nwGmNgpFFCIeg==",
+      "requires": {
+        "@hapi/address": "^2.1.2",
+        "@hapi/formula": "^1.2.0",
+        "@hapi/hoek": "^8.2.4",
+        "@hapi/pinpoint": "^1.0.2",
+        "@hapi/topo": "^3.1.3"
+      }
+    },
+    "@hapi/pinpoint": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-1.0.2.tgz",
+      "integrity": "sha512-dtXC/WkZBfC5vxscazuiJ6iq4j9oNx1SHknmIr8hofarpKUZKmlUVYVIhNVzIEgK5Wrc4GMHL5lZtt1uS2flmQ=="
+    },
+    "@hapi/topo": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
+      "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
+      "requires": {
+        "@hapi/hoek": "^8.3.0"
+      }
+    },
     "@types/aws-lambda": {
       "version": "8.10.34",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.34.tgz",
@@ -82,10 +122,10 @@
         "@types/range-parser": "*"
       }
     },
-    "@types/joi": {
-      "version": "14.3.4",
-      "resolved": "https://registry.npmjs.org/@types/joi/-/joi-14.3.4.tgz",
-      "integrity": "sha512-1TQNDJvIKlgYXGNIABfgFp9y0FziDpuGrd799Q5RcnsDu+krD+eeW/0Fs5PHARvWWFelOhIG2OPCo6KbadBM4A=="
+    "@types/hapi__joi": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@types/hapi__joi/-/hapi__joi-16.0.3.tgz",
+      "integrity": "sha512-gPxCfPcdZx9220GP4MFlhyBonQuyy8c/NZkGJkdtGipaExFzNLGYzkH2eG+yo0eEoVWdSC/JxhokSR/IHfap8Q=="
     },
     "@types/mime": {
       "version": "2.0.1",
@@ -472,11 +512,6 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
-    "hoek": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
-      "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ=="
-    },
     "http-errors": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
@@ -527,35 +562,10 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
-    "isemail": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
-      "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
-      "requires": {
-        "punycode": "2.x.x"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-        }
-      }
-    },
     "jmespath": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
-    },
-    "joi": {
-      "version": "14.3.1",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-14.3.1.tgz",
-      "integrity": "sha512-LQDdM+pkOrpAn4Lp+neNIFV3axv1Vna3j38bisbQhETPMANYRbFJFUyOZcOClYvM/hppMhGWuKSFEK9vjrB+bQ==",
-      "requires": {
-        "hoek": "6.x.x",
-        "isemail": "3.x.x",
-        "topo": "3.x.x"
-      }
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -856,14 +866,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
-    },
-    "topo": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
-      "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
-      "requires": {
-        "hoek": "6.x.x"
-      }
     },
     "ts-node": {
       "version": "8.4.1",

--- a/package.json
+++ b/package.json
@@ -14,11 +14,12 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@hapi/joi": "^16.1.7",
     "@types/aws-sdk": "^2.7.0",
     "@types/body-parser": "^1.17.1",
     "@types/cors": "^2.8.6",
     "@types/express": "^4.17.2",
-    "@types/joi": "^14.3.4",
+    "@types/hapi__joi": "^16.0.3",
     "@types/node": "^12.12.5",
     "@types/stripe": "^7.10.7",
     "@types/uuid": "^3.4.6",
@@ -27,7 +28,6 @@
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
-    "joi": "^14.3.1",
     "serverless-http": "^2.3.0",
     "stripe": "^7.11.0",
     "ts-node": "^8.4.1"

--- a/src/services/note.ts
+++ b/src/services/note.ts
@@ -2,14 +2,11 @@ import AWS = require('aws-sdk');
 import uuid from 'uuid';
 import Joi, {
   string,
-  number,
   object
-} from "joi";
+} from "@hapi/joi";
 import { ResponseDefaultType } from '../types/responseDefaultType';
 
 const dynamoDb = new AWS.DynamoDB.DocumentClient();
-
-
 
 const listNotes = (data: any, cb: (arg0: ResponseDefaultType) => void) => {
 
@@ -26,9 +23,9 @@ const listNotes = (data: any, cb: (arg0: ResponseDefaultType) => void) => {
     }).unknown(true)
   }).unknown(true);
 
-  const valid = Joi.validate(rparam, schema); // validate params
+  const { error, value } = schema.validate(rparam);
 
-  valid.then(val => {
+  if (error === undefined) {
 
     const queryParams = {
       TableName: process.env.NOTES_TABLE,
@@ -39,11 +36,11 @@ const listNotes = (data: any, cb: (arg0: ResponseDefaultType) => void) => {
     }
 
     const res: ResponseDefaultType = { status: 200, message: '' }; // set default value
-    dynamoDb.query(queryParams, (error, result) => {
+    dynamoDb.query(queryParams, (err, result) => {
 
-      if (error) {
-        res.status = error.statusCode,
-          res.message = error.message
+      if (err) {
+        res.status = err.statusCode,
+          res.message = err.message
       } else {
         res.status = 200;
         res.data = result.Items;
@@ -51,17 +48,16 @@ const listNotes = (data: any, cb: (arg0: ResponseDefaultType) => void) => {
       }
 
       cb(res);
+
     });
-  }).catch(reason => {
+  } else {
     const response: ResponseDefaultType = {
       status: 400,
-      message: reason
+      message: "Invalid parameters"
     }
+    console.log(error.details); // logs
     cb(response);
-  });
-
-
+  }
 }
-
 
 export { listNotes }


### PR DESCRIPTION
Changes:
Update from https://www.npmjs.com/package/joi version 14.3.1(Depracated)
to https://github.com/hapijs/joi (Supported and latest ver)