### PR TITLE
switch from actions/node to actions/setup-node because of deprecation…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: npm install
-        uses: actions/npm@master
+        uses: actions/setup-node@master
         with:
           args: install
       - name: serverless deploy


### PR DESCRIPTION
use actions/setup-node instead of actions/node because of deprecation warning..