### PR TITLE
Refact/serverless routing

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -41,30 +41,15 @@ resources:
   - ${file(resources/cognito-identity-pool.yml)}
 functions:
   app:
-    handler: dist/src/index.handler
+    handler: dist/index.handler
     events:
       - http:
-          path: notes
-          method: get
-          cors: true
+          path: /
+          method: ANY
+          cors: true  
           authorizer: aws_iam
       - http:
-          path: notes
-          method: post
-          cors: true
-          authorizer: aws_iam
-      - http:
-          path: notes/{id}
-          method: get
-          cors: true
-          authorizer: aws_iam
-      - http:
-          path: notes/{id}
-          method: put
-          cors: true
-          authorizer: aws_iam
-      - http:
-          path: notes/{id}
-          method: delete
+          path: /{proxy+}
+          method: ANY
           cors: true
           authorizer: aws_iam

--- a/src/services/note.ts
+++ b/src/services/note.ts
@@ -65,8 +65,9 @@ const createNote = (data: any, cb: (arg0: ResponseDefaultType) => void) => {
   // required param
   const rparam = {
     requestContext: data.requestContext,
-    body: JSON.parse(data.body)
+    body: data.body
   }
+  console.log("BODY: ", data.body);
 
   const schema = object({
     requestContext: object({
@@ -83,7 +84,7 @@ const createNote = (data: any, cb: (arg0: ResponseDefaultType) => void) => {
 
   if (error === undefined) {
 
-    const { content, attachment } = JSON.parse(data.body);
+    const { content, attachment } = data.body;
 
     const queryParams = {
       TableName: process.env.NOTES_TABLE,
@@ -182,7 +183,7 @@ const updateNote = (data: any, cb: (arg0: ResponseDefaultType) => void) => {
   // required param
   const rparam = {
     requestContext: data.requestContext,
-    body: JSON.parse(data.body)
+    body: data.body
   }
 
   const schema = object({
@@ -200,7 +201,7 @@ const updateNote = (data: any, cb: (arg0: ResponseDefaultType) => void) => {
 
   if (error === undefined) {
 
-    const { content, attachment } = JSON.parse(data.body);
+    const { content, attachment } = data.body;
 
     const queryParams = {
       TableName: process.env.NOTES_TABLE,


### PR DESCRIPTION
Updates:
 - Modify serverless.yml config for function app events http to use greedy path variable of {proxy+}
 - remove json.parse since body is already in json